### PR TITLE
Speed up fetching

### DIFF
--- a/fetcher/jvn/xml/jvn.go
+++ b/fetcher/jvn/xml/jvn.go
@@ -233,7 +233,7 @@ func convert(items []Item) (cves []models.CveDetail, err error) {
 		}
 	}()
 
-	concurrency := runtime.NumCPU()
+	concurrency := runtime.NumCPU() + 2
 	tasks := util.GenWorkers(concurrency)
 	for range items {
 		tasks <- func() {

--- a/fetcher/jvn/xml/jvn.go
+++ b/fetcher/jvn/xml/jvn.go
@@ -4,9 +4,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"strconv"
-	"strings"
-	"time"
+	"github.com/PuerkitoBio/goquery"
 	c "github.com/kotakanbe/go-cve-dictionary/config"
 	"github.com/kotakanbe/go-cve-dictionary/db"
 	"github.com/kotakanbe/go-cve-dictionary/fetcher"
@@ -14,8 +12,10 @@ import (
 	"github.com/kotakanbe/go-cve-dictionary/models"
 	"github.com/kotakanbe/go-cve-dictionary/util"
 	"net/http"
-	"github.com/PuerkitoBio/goquery"
 	"net/url"
+	"strconv"
+	"strings"
+	"time"
 )
 
 // Meta ... https://jvndb.jvn.jp/ja/feed/checksum.txt

--- a/fetcher/jvn/xml/jvn.go
+++ b/fetcher/jvn/xml/jvn.go
@@ -277,10 +277,9 @@ func convertToModel(item Item) (cves []models.CveDetail, err error) {
 	links := []CertLink{}
 	for _, ref := range item.References {
 		if ref.Source == "JPCERT-AT" {
-			link := CertLink{
+			links = append(links, CertLink{
 				Link: ref.URL,
-			}
-			links = append(links, link)
+			})
 		}
 	}
 

--- a/fetcher/jvn/xml/jvn.go
+++ b/fetcher/jvn/xml/jvn.go
@@ -4,6 +4,13 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"net/http"
+	"net/url"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/PuerkitoBio/goquery"
 	c "github.com/kotakanbe/go-cve-dictionary/config"
 	"github.com/kotakanbe/go-cve-dictionary/db"
@@ -11,11 +18,6 @@ import (
 	"github.com/kotakanbe/go-cve-dictionary/log"
 	"github.com/kotakanbe/go-cve-dictionary/models"
 	"github.com/kotakanbe/go-cve-dictionary/util"
-	"net/http"
-	"net/url"
-	"strconv"
-	"strings"
-	"time"
 )
 
 // Meta ... https://jvndb.jvn.jp/ja/feed/checksum.txt
@@ -218,15 +220,49 @@ func FetchConvert(metas []models.FeedMeta) (cves []models.CveDetail, err error) 
 }
 
 func convert(items []Item) (cves []models.CveDetail, err error) {
-	for _, item := range items {
-		converted, err := convertToModel(item)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to convert to model. JVN: %s, err: %s",
-				item.Identifier, err)
+	reqChan := make(chan Item, len(items))
+	resChan := make(chan []models.CveDetail, len(items))
+	errChan := make(chan error)
+	defer close(reqChan)
+	defer close(resChan)
+	defer close(errChan)
+
+	go func() {
+		for _, item := range items {
+			reqChan <- item
 		}
-		cves = append(cves, converted...)
+	}()
+
+	concurrency := runtime.NumCPU()
+	tasks := util.GenWorkers(concurrency)
+	for range items {
+		tasks <- func() {
+			req := <-reqChan
+			cves, err := convertToModel(&req)
+			if err != nil {
+				errChan <- err
+			}
+			resChan <- cves
+			return
+		}
 	}
-	return
+
+	errs := []error{}
+	timeout := time.After(10 * 60 * time.Second)
+	for range items {
+		select {
+		case res := <-resChan:
+			cves = append(cves, res...)
+		case err := <-errChan:
+			errs = append(errs, err)
+		case <-timeout:
+			return nil, fmt.Errorf("Timeout Fetching")
+		}
+	}
+	if 0 < len(errs) {
+		return nil, fmt.Errorf("%s", errs)
+	}
+	return cves, nil
 }
 
 func makeJvnURLs(years []int) (urls []string) {
@@ -252,7 +288,7 @@ func makeJvnURLs(years []int) (urls []string) {
 }
 
 // ConvertJvn converts Jvn structure(got from JVN) to model structure.
-func convertToModel(item Item) (cves []models.CveDetail, err error) {
+func convertToModel(item *Item) (cves []models.CveDetail, err error) {
 	var cvss2, cvss3 Cvss
 	for _, cvss := range item.Cvsses {
 		switch cvss.Version {
@@ -264,21 +300,17 @@ func convertToModel(item Item) (cves []models.CveDetail, err error) {
 	}
 
 	//  References
-	refs := []models.Reference{}
+	refs, links := []models.Reference{}, []CertLink{}
 	for _, r := range item.References {
 		ref := models.Reference{
 			Source: r.Source,
 			Link:   r.URL,
 		}
 		refs = append(refs, ref)
-	}
 
-	// Certs
-	links := []CertLink{}
-	for _, ref := range item.References {
 		if ref.Source == "JPCERT-AT" {
 			links = append(links, CertLink{
-				Link: ref.URL,
+				Link: r.URL,
 			})
 		}
 	}
@@ -310,7 +342,7 @@ func convertToModel(item Item) (cves []models.CveDetail, err error) {
 		return nil, err
 	}
 
-	cveIDs := getCveIDs(item)
+	cveIDs := getCveIDs(*item)
 	if len(cveIDs) == 0 {
 		log.Debugf("No CveIDs in references. JvnID: %s, Link: %s",
 			item.Identifier, item.Link)
@@ -379,8 +411,8 @@ func collectCertLinks(links []CertLink) (certs []models.Cert, err error) {
 		httpCilent = &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
 	}
 
-	reqChan := make(chan string, 10)
-	resChan := make(chan models.Cert, 10)
+	reqChan := make(chan string, len(links))
+	resChan := make(chan models.Cert, len(links))
 	errChan := make(chan error, len(links))
 	defer close(reqChan)
 	defer close(resChan)
@@ -392,10 +424,8 @@ func collectCertLinks(links []CertLink) (certs []models.Cert, err error) {
 		}
 	}()
 
-	concurrency := 3
+	concurrency := runtime.NumCPU()
 	tasks := util.GenWorkers(concurrency)
-	certs = []models.Cert{}
-
 	for _, l := range links {
 		tasks <- func() {
 			req := <-reqChan

--- a/fetcher/nvd/json/nvd.go
+++ b/fetcher/nvd/json/nvd.go
@@ -44,7 +44,7 @@ func FetchConvert(metas []models.FeedMeta) (cves []models.CveDetail, err error) 
 				"Failed to unmarshal. url: %s, err: %s",
 				res.URL, err)
 		}
-		cs, err := convertConcurrently(nvd.CveItems)
+		cs, err := convert(nvd.CveItems)
 		if err != nil {
 			errs = append(errs, err)
 		}
@@ -56,7 +56,7 @@ func FetchConvert(metas []models.FeedMeta) (cves []models.CveDetail, err error) 
 	return cves, nil
 }
 
-func convertConcurrently(items []CveItem) (cves []models.CveDetail, err error) {
+func convert(items []CveItem) (cves []models.CveDetail, err error) {
 	reqChan := make(chan CveItem, len(items))
 	resChan := make(chan *models.CveDetail, len(items))
 	errChan := make(chan error, len(items))
@@ -64,25 +64,22 @@ func convertConcurrently(items []CveItem) (cves []models.CveDetail, err error) {
 	defer close(resChan)
 	defer close(errChan)
 
-	concurrency := runtime.NumCPU()
-	tasks := util.GenWorkers(concurrency)
-
 	go func() {
 		for _, item := range items {
 			reqChan <- item
 		}
 	}()
 
+	concurrency := runtime.NumCPU()
+	tasks := util.GenWorkers(concurrency)
 	for range items {
 		tasks <- func() {
-			select {
-			case req := <-reqChan:
-				cve, err := convertToModel(&req)
-				if err != nil {
-					errChan <- err
-				}
-				resChan <- cve
+			req := <-reqChan
+			cve, err := convertToModel(&req)
+			if err != nil {
+				errChan <- err
 			}
+			resChan <- cve
 			return
 		}
 	}
@@ -457,8 +454,8 @@ func collectCertLinks(links []CertLink) (certs []models.Cert, err error) {
 		httpCilent = &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
 	}
 
-	reqChan := make(chan string, 10)
-	resChan := make(chan models.Cert, 10)
+	reqChan := make(chan string, len(links))
+	resChan := make(chan models.Cert, len(links))
 	errChan := make(chan error, len(links))
 	defer close(reqChan)
 	defer close(resChan)
@@ -470,10 +467,8 @@ func collectCertLinks(links []CertLink) (certs []models.Cert, err error) {
 		}
 	}()
 
-	concurrency := 3
+	concurrency := runtime.NumCPU()
 	tasks := util.GenWorkers(concurrency)
-	certs = []models.Cert{}
-
 	for _, l := range links {
 		tasks <- func() {
 			req := <-reqChan

--- a/fetcher/nvd/json/nvd.go
+++ b/fetcher/nvd/json/nvd.go
@@ -70,7 +70,7 @@ func convert(items []CveItem) (cves []models.CveDetail, err error) {
 		}
 	}()
 
-	concurrency := runtime.NumCPU()
+	concurrency := runtime.NumCPU() + 2
 	tasks := util.GenWorkers(concurrency)
 	for range items {
 		tasks <- func() {

--- a/fetcher/nvd/json/nvd.go
+++ b/fetcher/nvd/json/nvd.go
@@ -203,10 +203,9 @@ func convertToModel(item *CveItem) (*models.CveDetail, error) {
 	for _, ref := range item.Cve.References.ReferenceData {
 		tag := strings.Join(ref.TAGS, " ")
 		if strings.Contains(ref.URL, "ncas/alerts") || strings.Contains(ref.URL, "cas/techalerts") || strings.Contains(tag, "US Government Resource") {
-			link := CertLink{
+			links = append(links, CertLink{
 				Link: ref.URL,
-			}
-			links = append(links, link)
+			})
 		}
 	}
 

--- a/fetcher/nvd/json/nvd.go
+++ b/fetcher/nvd/json/nvd.go
@@ -3,19 +3,21 @@ package json
 import (
 	"encoding/json"
 	"fmt"
+	"runtime"
 	"strings"
 	"time"
 
-	c "github.com/kotakanbe/go-cve-dictionary/config"
+	"net/http"
+	"net/url"
+
+	"github.com/PuerkitoBio/goquery"
 	"github.com/hashicorp/go-version"
 	"github.com/k0kubun/pp"
+	c "github.com/kotakanbe/go-cve-dictionary/config"
 	"github.com/kotakanbe/go-cve-dictionary/fetcher"
 	"github.com/kotakanbe/go-cve-dictionary/log"
 	"github.com/kotakanbe/go-cve-dictionary/models"
 	"github.com/kotakanbe/go-cve-dictionary/util"
-	"net/url"
-	"net/http"
-	"github.com/PuerkitoBio/goquery"
 )
 
 // FetchConvert Fetch CVE vulnerability information from NVD
@@ -34,6 +36,7 @@ func FetchConvert(metas []models.FeedMeta) (cves []models.CveDetail, err error) 
 			fmt.Errorf("Failed to fetch. err: %s", err)
 	}
 
+	errs := []error{}
 	for _, res := range results {
 		nvd := NvdJSON{}
 		if err = json.Unmarshal(res.Body, &nvd); err != nil {
@@ -41,16 +44,65 @@ func FetchConvert(metas []models.FeedMeta) (cves []models.CveDetail, err error) 
 				"Failed to unmarshal. url: %s, err: %s",
 				res.URL, err)
 		}
-		for _, item := range nvd.CveItems {
-			cve, err := convertToModel(&item)
-			if err != nil {
-				return nil, fmt.Errorf("Failed to convert to model. cve: %s, err: %s",
-					item.Cve.CveDataMeta.ID, err)
+		cs, err := convertConcurrently(nvd.CveItems)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		cves = append(cves, cs...)
+	}
+	if 0 < len(errs) {
+		return nil, fmt.Errorf("%s", errs)
+	}
+	return cves, nil
+}
+
+func convertConcurrently(items []CveItem) (cves []models.CveDetail, err error) {
+	reqChan := make(chan CveItem, len(items))
+	resChan := make(chan *models.CveDetail, len(items))
+	errChan := make(chan error, len(items))
+	defer close(reqChan)
+	defer close(resChan)
+	defer close(errChan)
+
+	concurrency := runtime.NumCPU()
+	tasks := util.GenWorkers(concurrency)
+
+	go func() {
+		for _, item := range items {
+			reqChan <- item
+		}
+	}()
+
+	for range items {
+		tasks <- func() {
+			select {
+			case req := <-reqChan:
+				cve, err := convertToModel(&req)
+				if err != nil {
+					errChan <- err
+				}
+				resChan <- cve
 			}
-			cves = append(cves, *cve)
+			return
 		}
 	}
-	return
+
+	errs := []error{}
+	timeout := time.After(10 * 60 * time.Second)
+	for range items {
+		select {
+		case res := <-resChan:
+			cves = append(cves, *res)
+		case err := <-errChan:
+			errs = append(errs, err)
+		case <-timeout:
+			return nil, fmt.Errorf("Timeout Fetching")
+		}
+	}
+	if 0 < len(errs) {
+		return nil, fmt.Errorf("%s", errs)
+	}
+	return cves, nil
 }
 
 // NvdJSON is a struct of NVD JSON


### PR DESCRIPTION
tested on : 4core, 4GB

# NVD  fetch 2019

concurrency | time consumption
------------ | -------------
1(current implementation) |  4m30s
2 | 73s
4 | 50s
8 | 55s

# JVN fetch 2018

concurrency | time consumption
------------ | -------------
1(current implementation) |  40s
4 | 13s
